### PR TITLE
Minor fix at the role example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - metricbeat
+         - tbaczynski.metricbeat
 
 License
 -------


### PR DESCRIPTION
Have to include the author's name as a prefix on the role otherwise ansible would complain that it cannot find it.