### PR TITLE
Add missing  gpg prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - metricbeat
+         - tbaczynski.metricbeat
 
 License
 -------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name:
       - apt-transport-https
+      - gpg
     state: present
   tags: metricbeat
 


### PR DESCRIPTION
Noticed that in my setup (LXD Ubuntu bionic cloud image) the role was failing due to a missing executable (gpg)

`{"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}`